### PR TITLE
Add smooth transitions for the landing CTA buttons

### DIFF
--- a/webpack/app/styles/header.css
+++ b/webpack/app/styles/header.css
@@ -24,7 +24,7 @@
 }
 
 .header-button-group-button {
-  transition: background 0.3s;
+  transition: background 0.3s, border 0.3s, color 0.3s;
   @apply bg-transparent text-blue-dark font-semibold py-3 px-5 mx-5 border border-blue rounded no-underline;
 }
 


### PR DESCRIPTION
Add border and color transitions for the CTA buttons on the landing page.

Before:
![before](https://user-images.githubusercontent.com/37555845/57615044-665c4780-7583-11e9-8b39-6d223df32ad9.gif)

Now:
![now](https://user-images.githubusercontent.com/37555845/57615047-665c4780-7583-11e9-9486-967787d4c572.gif)
